### PR TITLE
Changed command for getting the load average.

### DIFF
--- a/scripts/load_average.sh
+++ b/scripts/load_average.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 print_load_average() {
-    printf "$(uptime | cut -d ':' -f4)"
+    printf "$(uptime | awk -F "average:" '{print $2}')"
 }
 
 main() {


### PR DESCRIPTION
Previous implementation was failing when the "uptime" command
returned seconds also in the uptime.

This should handle both cases.

###### Tested in Arch Linux where the problem occured.