### PR TITLE
make print_load_average work on OSX

### DIFF
--- a/scripts/load_average.sh
+++ b/scripts/load_average.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 print_load_average() {
-    printf "$(uptime | awk -F "average:" '{print $2}')"
+    printf "$(uptime | awk -F "averages?:" '{print $2}')"
 }
 
 main() {


### PR DESCRIPTION
... where the "uptime" command replies with a plural:

    $ uptime
    18:55  up  9:17, 1 user, load averages: 2.36 2.35 2.21